### PR TITLE
Refactor analytics and supplier classes to use singleton pattern

### DIFF
--- a/admin/class-srwm-admin-dashboard.php
+++ b/admin/class-srwm-admin-dashboard.php
@@ -78,7 +78,7 @@ class SRWM_Admin_Dashboard {
      * Render main dashboard page
      */
     public function render_dashboard() {
-        $analytics = new SRWM_Analytics();
+        $analytics = SRWM_Analytics::get_instance();
         $dashboard_data = $analytics->get_dashboard_data();
         ?>
         <div class="wrap srwm-dashboard">
@@ -311,7 +311,7 @@ class SRWM_Admin_Dashboard {
             wp_die(__('Insufficient permissions.', 'smart-restock-waitlist'));
         }
         
-        $analytics = new SRWM_Analytics();
+        $analytics = SRWM_Analytics::get_instance();
         $data = array(
             'dashboard_data' => $analytics->get_dashboard_data(),
             'waitlist_growth' => $analytics->get_waitlist_growth_trend(30),
@@ -332,7 +332,7 @@ class SRWM_Admin_Dashboard {
             wp_die(__('Insufficient permissions.', 'smart-restock-waitlist'));
         }
         
-        $analytics = new SRWM_Analytics();
+        $analytics = SRWM_Analytics::get_instance();
         $analytics->export_analytics_csv();
     }
 }

--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -517,7 +517,7 @@ class SRWM_Admin {
      * Render analytics page
      */
     public function render_analytics_page() {
-        $analytics = new SRWM_Analytics();
+        $analytics = SRWM_Analytics::get_instance();
         $analytics_data = $analytics->get_analytics_data();
         ?>
         <div class="wrap">
@@ -639,7 +639,7 @@ class SRWM_Admin {
         
         $table = $wpdb->prefix . 'srwm_waitlist';
         
-        return $wpdb->get_results($wpdb->prepare(
+        return $wpdb->get_results(
             "SELECT p.ID as product_id, p.post_title as name, pm.meta_value as sku,
                     wc.stock_quantity as stock, COUNT(w.id) as waitlist_count
              FROM {$wpdb->posts} p
@@ -649,14 +649,15 @@ class SRWM_Admin {
              WHERE p.post_type = 'product' AND p.post_status = 'publish'
              GROUP BY p.ID
              ORDER BY waitlist_count DESC",
-        ), ARRAY_A);
+            ARRAY_A
+        );
     }
     
     /**
      * Get products with supplier alerts
      */
     private function get_supplier_products() {
-        $supplier = new SRWM_Supplier();
+        $supplier = SRWM_Supplier::get_instance();
         return $supplier->get_products_with_suppliers();
     }
     

--- a/includes/class-srwm-analytics.php
+++ b/includes/class-srwm-analytics.php
@@ -79,13 +79,13 @@ class SRWM_Analytics {
         $waitlist_table = $wpdb->prefix . 'srwm_waitlist';
         $logs_table = $wpdb->prefix . 'srwm_restock_logs';
         
-        $result = $wpdb->get_var($wpdb->prepare(
+        $result = $wpdb->get_var(
             "SELECT AVG(DATEDIFF(r.timestamp, w.date_added)) as avg_days
              FROM $logs_table r
              JOIN $waitlist_table w ON r.product_id = w.product_id
              WHERE w.date_added <= r.timestamp
              AND w.notified = 1"
-        ));
+        );
         
         return round($result, 1);
     }


### PR DESCRIPTION
FIXES APPLIED
1. Fixed Private Constructor Issues

    ✅ Line 520 in includes/class-srwm-admin.php: Changed new SRWM_Analytics() to SRWM_Analytics::get_instance()
    ✅ Line 659 in includes/class-srwm-admin.php: Changed new SRWM_Supplier() to SRWM_Supplier::get_instance()
    ✅ Line 75 in admin/class-srwm-admin-dashboard.php: Changed new SRWM_Analytics() to SRWM_Analytics::get_instance()
    ✅ Line 313 in admin/class-srwm-admin-dashboard.php: Changed new SRWM_Analytics() to SRWM_Analytics::get_instance()
    ✅ Line 334 in admin/class-srwm-admin-dashboard.php: Changed new SRWM_Analytics() to SRWM_Analytics::get_instance()

2. Fixed wpdb::prepare() Issues

    ✅ Line 82 in includes/class-srwm-analytics.php: Removed unnecessary wpdb::prepare() call without placeholders
    ✅ Line 641 in includes/class-srwm-admin.php: Removed unnecessary wpdb::prepare() call without placeholders

🎯 Root Cause Analysis

The errors occurred because:

    Singleton Pattern Violation: The classes SRWM_Analytics and SRWM_Supplier use the singleton pattern with private constructors, but were being instantiated directly with new instead of using the get_instance() method.

    Incorrect wpdb::prepare() Usage: The wpdb::prepare() function requires at least one placeholder (%s, %d, etc.) in the query string, but some calls were made without any placeholders.

✅ Current Status

All the errors should now be resolved:

    ✅ Dashboard: Should load without fatal errors
    ✅ Analytics: Should display properly
    ✅ Database Queries: All wpdb::prepare() calls are now correct
    ✅ Class Instantiation: All classes now use proper singleton pattern
