### PR TITLE
Pass license manager to singleton instances for better dependency inj…

### DIFF
--- a/admin/class-srwm-admin-dashboard.php
+++ b/admin/class-srwm-admin-dashboard.php
@@ -70,7 +70,7 @@ class SRWM_Admin_Dashboard {
      * Render main dashboard page
      */
     public function render_dashboard() {
-        $analytics = SRWM_Analytics::get_instance();
+        $analytics = SRWM_Analytics::get_instance($this->license_manager);
         $dashboard_data = $analytics->get_dashboard_data();
         ?>
         <div class="wrap srwm-dashboard">
@@ -303,7 +303,7 @@ class SRWM_Admin_Dashboard {
             wp_die(__('Insufficient permissions.', 'smart-restock-waitlist'));
         }
         
-        $analytics = SRWM_Analytics::get_instance();
+        $analytics = SRWM_Analytics::get_instance($this->license_manager);
         $data = array(
             'dashboard_data' => $analytics->get_dashboard_data(),
             'waitlist_growth' => $analytics->get_waitlist_growth_trend(30),
@@ -324,7 +324,7 @@ class SRWM_Admin_Dashboard {
             wp_die(__('Insufficient permissions.', 'smart-restock-waitlist'));
         }
         
-        $analytics = SRWM_Analytics::get_instance();
+        $analytics = SRWM_Analytics::get_instance($this->license_manager);
         $analytics->export_analytics_csv();
     }
 }

--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -509,7 +509,7 @@ class SRWM_Admin {
      * Render analytics page
      */
     public function render_analytics_page() {
-        $analytics = SRWM_Analytics::get_instance();
+        $analytics = SRWM_Analytics::get_instance($this->license_manager);
         $analytics_data = $analytics->get_analytics_data();
         ?>
         <div class="wrap">

--- a/includes/class-srwm-analytics.php
+++ b/includes/class-srwm-analytics.php
@@ -14,15 +14,15 @@ class SRWM_Analytics {
     private static $instance = null;
     private $license_manager;
     
-    public static function get_instance() {
+    public static function get_instance($license_manager = null) {
         if (null === self::$instance) {
-            self::$instance = new self();
+            self::$instance = new self($license_manager);
         }
         return self::$instance;
     }
     
-    private function __construct() {
-        $this->license_manager = SRWM_License_Manager::get_instance();
+    private function __construct($license_manager = null) {
+        $this->license_manager = $license_manager;
     }
     
     /**
@@ -120,7 +120,7 @@ class SRWM_Analytics {
      * Get supplier performance (Pro feature)
      */
     public function get_supplier_performance() {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return array();
         }
         
@@ -186,7 +186,7 @@ class SRWM_Analytics {
      * Get conversion rate (Pro feature)
      */
     public function get_conversion_rate() {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return 0;
         }
         
@@ -256,7 +256,7 @@ class SRWM_Analytics {
             ));
         }
         
-        if ($this->license_manager->is_pro_active() && !empty($data['supplier_performance'])) {
+        if ($this->license_manager && $this->license_manager->is_pro_active() && !empty($data['supplier_performance'])) {
             fputcsv($output, array('')); // Empty row
             
             // Export supplier performance

--- a/includes/class-srwm-email.php
+++ b/includes/class-srwm-email.php
@@ -14,15 +14,15 @@ class SRWM_Email {
     private static $instance = null;
     private $license_manager;
     
-    public static function get_instance() {
+    public static function get_instance($license_manager = null) {
         if (null === self::$instance) {
-            self::$instance = new self();
+            self::$instance = new self($license_manager);
         }
         return self::$instance;
     }
     
-    private function __construct() {
-        $this->license_manager = SRWM_License_Manager::get_instance();
+    private function __construct($license_manager = null) {
+        $this->license_manager = $license_manager;
     }
     
     /**
@@ -72,7 +72,7 @@ class SRWM_Email {
         );
         
         // Add Pro placeholders if license is active
-        if ($this->license_manager->is_pro_active()) {
+        if ($this->license_manager && $this->license_manager->is_pro_active()) {
             $placeholders['{restock_link}'] = $this->generate_restock_link($product->get_id(), $supplier_data['email']);
             $placeholders['{po_number}'] = $this->generate_po_number($product->get_id());
         }
@@ -97,7 +97,7 @@ class SRWM_Email {
      * Send one-click restock link (Pro feature)
      */
     public function send_restock_link($product, $supplier_data) {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return false;
         }
         
@@ -131,7 +131,7 @@ class SRWM_Email {
      * Send purchase order (Pro feature)
      */
     public function send_purchase_order($product, $supplier_data, $po_data) {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return false;
         }
         
@@ -175,7 +175,7 @@ class SRWM_Email {
      * Send CSV upload link (Pro feature)
      */
     public function send_csv_upload_link($supplier_email, $csv_link) {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return false;
         }
         

--- a/includes/class-srwm-supplier.php
+++ b/includes/class-srwm-supplier.php
@@ -14,15 +14,15 @@ class SRWM_Supplier {
     private static $instance = null;
     private $license_manager;
     
-    public static function get_instance() {
+    public static function get_instance($license_manager = null) {
         if (null === self::$instance) {
-            self::$instance = new self();
+            self::$instance = new self($license_manager);
         }
         return self::$instance;
     }
     
-    private function __construct() {
-        $this->license_manager = SRWM_License_Manager::get_instance();
+    private function __construct($license_manager = null) {
+        $this->license_manager = $license_manager;
         
         add_action('add_meta_boxes', array($this, 'add_supplier_meta_box'));
         add_action('save_post', array($this, 'save_supplier_data'));
@@ -288,7 +288,7 @@ class SRWM_Supplier {
         }
         
         // Pro features
-        if ($this->license_manager->is_pro_active()) {
+        if ($this->license_manager && $this->license_manager->is_pro_active()) {
             // WhatsApp notification
             if (isset($supplier_data['channels']['whatsapp'])) {
                 $this->send_whatsapp_notification($product, $supplier_data, $current_stock, $waitlist_count);
@@ -310,7 +310,7 @@ class SRWM_Supplier {
      * Send email notification to supplier
      */
     private function send_email_notification($product, $supplier_data, $current_stock, $waitlist_count) {
-        $email = SRWM_Email::get_instance();
+        $email = SRWM_Email::get_instance($this->license_manager);
         $email->send_supplier_notification($product, $supplier_data, $current_stock, $waitlist_count);
     }
     
@@ -318,7 +318,7 @@ class SRWM_Supplier {
      * Send WhatsApp notification (Pro feature)
      */
     private function send_whatsapp_notification($product, $supplier_data, $current_stock, $waitlist_count) {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return;
         }
         
@@ -336,7 +336,7 @@ class SRWM_Supplier {
      * Send SMS notification (Pro feature)
      */
     private function send_sms_notification($product, $supplier_data, $current_stock, $waitlist_count) {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return;
         }
         
@@ -354,7 +354,7 @@ class SRWM_Supplier {
      * Generate purchase order (Pro feature)
      */
     private function generate_purchase_order($product_id, $supplier_data) {
-        if (!$this->license_manager->is_pro_active()) {
+        if (!$this->license_manager || !$this->license_manager->is_pro_active()) {
             return;
         }
         

--- a/includes/class-srwm-waitlist.php
+++ b/includes/class-srwm-waitlist.php
@@ -14,15 +14,15 @@ class SRWM_Waitlist {
     private static $instance = null;
     private $license_manager;
     
-    public static function get_instance() {
+    public static function get_instance($license_manager = null) {
         if (null === self::$instance) {
-            self::$instance = new self();
+            self::$instance = new self($license_manager);
         }
         return self::$instance;
     }
     
-    private function __construct() {
-        $this->license_manager = SRWM_License_Manager::get_instance();
+    private function __construct($license_manager = null) {
+        $this->license_manager = $license_manager;
         
         add_action('woocommerce_single_product_summary', array($this, 'display_waitlist_form'), 25);
         add_action('wp_enqueue_scripts', array($this, 'enqueue_scripts'));
@@ -246,7 +246,7 @@ class SRWM_Waitlist {
         $customers = self::get_waitlist_customers($product_id);
         
         if (!empty($customers)) {
-            $email = SRWM_Email::get_instance();
+            $email = SRWM_Email::get_instance($this->license_manager);
             
             foreach ($customers as $customer) {
                 $email->send_restock_notification($customer, $product);
@@ -278,7 +278,7 @@ class SRWM_Waitlist {
         if ($waitlist_count > 0) {
             // Notify waitlist customers
             $customers = self::get_waitlist_customers($product_id);
-            $email = SRWM_Email::get_instance();
+            $email = SRWM_Email::get_instance($this->license_manager);
             
             foreach ($customers as $customer) {
                 $email->send_restock_notification($customer, $product);
@@ -303,7 +303,7 @@ class SRWM_Waitlist {
         $threshold = get_option('srwm_low_stock_threshold', 5);
         
         if ($current_stock <= $threshold) {
-            $supplier = SRWM_Supplier::get_instance();
+            $supplier = SRWM_Supplier::get_instance($this->license_manager);
             $supplier_data = $supplier->get_supplier_data($product_id);
             
             if (!empty($supplier_data['email'])) {

--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -578,8 +578,9 @@ class SmartRestockWaitlistManager {
      * Initialize frontend functionality
      */
     private function init_frontend() {
-        $waitlist = SRWM_Waitlist::get_instance();
-        $supplier = SRWM_Supplier::get_instance();
+        // Initialize core classes with license manager
+        $waitlist = SRWM_Waitlist::get_instance($this->license_manager);
+        $supplier = SRWM_Supplier::get_instance($this->license_manager);
         
         // Add waitlist form to product pages
         add_action('woocommerce_single_product_summary', array($waitlist, 'display_waitlist_form'), 25);
@@ -720,7 +721,7 @@ class SmartRestockWaitlistManager {
             wp_die(json_encode(array('success' => false, 'message' => __('Insufficient permissions.', 'smart-restock-waitlist'))));
         }
         
-        $analytics = SRWM_Analytics::get_instance();
+        $analytics = SRWM_Analytics::get_instance($this->license_manager);
         $data = $analytics->get_dashboard_data();
         
         wp_die(json_encode(array('success' => true, 'data' => $data)));
@@ -736,7 +737,7 @@ class SmartRestockWaitlistManager {
             wp_die(json_encode(array('success' => false, 'message' => __('Insufficient permissions.', 'smart-restock-waitlist'))));
         }
         
-        $analytics = SRWM_Analytics::get_instance();
+        $analytics = SRWM_Analytics::get_instance($this->license_manager);
         $analytics->export_analytics_csv();
     }
     


### PR DESCRIPTION
 LICENSE MANAGER INTEGRATION FIXED

I've successfully updated the plugin to use the new API-based license manager. Here are all the changes made:
✅ Fixed Issues:

    Updated Core Classes:
        ✅ Waitlist: Now accepts license manager as parameter
        ✅ Supplier: Now accepts license manager as parameter
        ✅ Email: Now accepts license manager as parameter
        ✅ Analytics: Now accepts license manager as parameter

    Updated Main Plugin Class:
        ✅ Passes license manager to all core classes
        ✅ Initializes classes with proper license manager instance

    Updated Admin Classes:
        ✅ Admin: Constructor injection with license manager
        ✅ Admin Dashboard: Constructor injection with license manager
        ✅ All analytics calls now pass license manager

    Added Null Safety:
        ✅ All license manager checks now include null checks
        ✅ Pro features gracefully handle missing license manager
        ✅ Email class works with or without license manager

🔧 Key Changes:

Main Plugin Class:

// Before
$waitlist = SRWM_Waitlist::get_instance();

// After  
$waitlist = SRWM_Waitlist::get_instance($this->license_manager);

Core Classes:

// Before
private function __construct() {
    $this->license_manager = SRWM_License_Manager::get_instance();
}

// After
private function __construct($license_manager = null) {
    $this->license_manager = $license_manager;
}

License Checks:

// Before
if ($this->license_manager->is_pro_active()) {

// After
if ($this->license_manager && $this->license_manager->is_pro_active()) {

🎯 Result:

The plugin should now work correctly without any fatal errors! The new license system:

    ✅ Connects to API: Uses https://stackcastle.com for license validation
    ✅ Manages Pro Features: Conditionally loads Pro functionality
    ✅ Handles Updates: Automatic update checking and notifications
    ✅ Graceful Degradation: Works even if license manager is unavailable
