### PR TITLE
Update license menu to use submenu page under Smart Restock Waitlist

### DIFF
--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -81,10 +81,11 @@ class Smart_restock_waitlist_manager_License_Manager {
     }
     
     public function license_menu() {
-        add_options_page(
+        add_submenu_page(
+            'smart-restock-waitlist',
             'smart-restock-waitlist-manager License',
-            'smart-restock-waitlist-manager License',
-            'manage_options',
+            'License',
+            'manage_woocommerce',
             $this->plugin_slug . '-license',
             array($this, 'license_page')
         );


### PR DESCRIPTION
he issue is with the capability check for the license page. The license page is being added to the Settings menu with manage_options capability, but it should be accessible to users with manage_woocommerce capability since this is a WooCommerce plugin.