### PR TITLE
Remove pro features marketing sections from admin dashboard and licen…

### DIFF
--- a/admin/class-srwm-admin-dashboard.php
+++ b/admin/class-srwm-admin-dashboard.php
@@ -182,9 +182,6 @@ class SRWM_Admin_Dashboard {
                     <a href="<?php echo admin_url('admin.php?page=smart-restock-waitlist-license'); ?>" class="button button-primary">
                         <?php _e('Get Pro License', 'smart-restock-waitlist'); ?>
                     </a>
-                    <a href="https://example.com/pro-features" class="button button-secondary" target="_blank">
-                        <?php _e('Learn More', 'smart-restock-waitlist'); ?>
-                    </a>
                 </div>
             </div>
         </div>

--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -265,21 +265,7 @@ class SRWM_License_Manager {
                 </form>
             </div>
             
-            <?php if ($status !== 'valid'): ?>
-            <div class="card" style="max-width: 600px; margin-top: 20px;">
-                <h2><?php _e('Pro Features', 'smart-restock-waitlist'); ?></h2>
-                <p><?php _e('Upgrade to Pro to unlock advanced features:', 'smart-restock-waitlist'); ?></p>
-                <ul>
-                    <li><?php _e('One-Click Supplier Restock Links', 'smart-restock-waitlist'); ?></li>
-                    <li><?php _e('Automatic Purchase Order Generation', 'smart-restock-waitlist'); ?></li>
-                    <li><?php _e('Supplier CSV Upload for Bulk Restock', 'smart-restock-waitlist'); ?></li>
-                    <li><?php _e('WhatsApp & SMS Notifications', 'smart-restock-waitlist'); ?></li>
-                    <li><?php _e('Advanced Analytics & Reporting', 'smart-restock-waitlist'); ?></li>
-                    <li><?php _e('Automatic Updates', 'smart-restock-waitlist'); ?></li>
-                </ul>
-                <p><a href="https://yourwebsite.com/pro" class="button button-primary" target="_blank"><?php _e('Get Pro License', 'smart-restock-waitlist'); ?></a></p>
-            </div>
-            <?php endif; ?>
+            
         </div>
         
         <style>


### PR DESCRIPTION
UPGRADE NOTICES FIXED

I've successfully cleaned up all the upgrade notices to ensure they all point to the proper license page. Here's what I fixed:
🔧 Changes Made:

    Removed External Link: Removed the "Learn More" button that was linking to https://example.com/pro-features
    Consistent License Links: All upgrade notices now properly link to the license page: admin.php?page=smart-restock-waitlist-license

✅ Current Status:

All upgrade notices now correctly point to the license page:

    ✅ Admin Dashboard: Links to license page ✅
    ✅ Admin Settings: Links to license page ✅
    ✅ Email Templates: Links to license page ✅
    ✅ Supplier Meta Box: Text only (no link) ✅

🎯 Result:

Now when users see any "Upgrade to Pro" or "Get Pro License" button, they will all go to the same place - the license page where they can enter their license key and activate it through your API.

No more confusion with different links! All upgrade paths now lead to the proper license activation system. 🚀