### PR TITLE
Fix missing endif tag in admin template rendering

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -446,7 +446,7 @@ class SRWM_Admin {
                         </td>
                     </tr>
                 </table>
-
+                <?php endif; ?>
                 
                 <h2><?php _e('Email Templates', 'smart-restock-waitlist'); ?></h2>
                 


### PR DESCRIPTION
 SYNTAX ERROR FIXED

The parse error has been resolved! The issue was:

    Problem: Missing <?php endif; ?> after removing the upgrade notice
    Solution: Added the missing <?php endif; ?> to properly close the if statement

The plugin should now work without any syntax errors! 🚀