### PR TITLE
Fix duplicate endif statement in admin class

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -474,6 +474,7 @@ class SRWM_Admin {
                     <?php endif; ?>
                 </div>
                 <?php endif; ?>
+                <?php endif; ?>
             </div>
         </div>
         


### PR DESCRIPTION
SYNTAX ERROR FIXED

The parse error has been resolved! The issue was:

    Problem: Missing <?php endif; ?> for the supplier products if statement
    Solution: Added the missing <?php endif; ?> statement

The plugin should now work correctly without any syntax errors! 🚀