### PR TITLE
Remove redundant endif statement in admin class

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -474,7 +474,6 @@ class SRWM_Admin {
                     <?php endif; ?>
                 </div>
                 <?php endif; ?>
-                <?php endif; ?>
             </div>
         </div>
         


### PR DESCRIPTION
SYNTAX ERROR FIXED

Root Cause Analysis:

    Problem: Extra <?php endif; ?> statement without a corresponding if statement
    Location: Line 477 in the dashboard method
    Solution: Removed the extra <?php endif; ?> statement

If/Endif Structure (Corrected):

    if ($this->license_manager->is_pro_active()) → endif ✅
    if ($this->license_manager->is_pro_active()) → endif ✅
    if ($this->license_manager->is_pro_active()) → endif ✅
    if (!empty($waitlist_products)) → endif ✅
    if (!empty($supplier_products)) → endif ✅

The plugin should now work without any syntax errors! 🚀