### PR TITLE
Remove redundant endif statement in admin class

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -473,7 +473,6 @@ class SRWM_Admin {
                     </div>
                     <?php endif; ?>
                 </div>
-                <?php endif; ?>
             </div>
         </div>
         


### PR DESCRIPTION
SYNTAX ERROR FIXED

Root Cause Analysis:

    Problem: Duplicate <?php endif; ?> statements for the same if block
    Location: Lines 476-477 in the dashboard method
    Issue: The if (!empty($supplier_products)) statement was being closed by TWO endif statements instead of one

Correct Structure Now:

    if (!empty($supplier_products)) → ONE endif ✅
    The extra endif that had no corresponding if statement has been removed ✅

The plugin should now work without any syntax errors! The error was caused by having an orphaned <?php endif; ?> statement that didn't have a matching <?php if statement. 🚀