### PR TITLE
Update supplier table column names for consistency and clarity

### DIFF
--- a/includes/class-srwm-analytics.php
+++ b/includes/class-srwm-analytics.php
@@ -130,14 +130,14 @@ class SRWM_Analytics {
         $logs_table = $wpdb->prefix . 'srwm_restock_logs';
         
         return $wpdb->get_results(
-            "SELECT s.name as supplier_name, s.email as supplier_email,
+            "SELECT s.supplier_name, s.supplier_email,
                     COUNT(DISTINCT s.product_id) as products_managed,
                     COUNT(r.id) as total_restocks,
                     AVG(r.quantity) as avg_restock_quantity,
-                    AVG(DATEDIFF(r.timestamp, s.date_created)) as avg_response_time
+                    AVG(DATEDIFF(r.timestamp, s.created_at)) as avg_response_time
              FROM $suppliers_table s
              LEFT JOIN $logs_table r ON s.product_id = r.product_id
-             GROUP BY s.email
+             GROUP BY s.supplier_email
              ORDER BY total_restocks DESC"
         , ARRAY_A);
     }

--- a/includes/class-srwm-supplier.php
+++ b/includes/class-srwm-supplier.php
@@ -181,8 +181,8 @@ class SRWM_Supplier {
         
         $data = array(
             'product_id' => $product_id,
-            'email' => $email,
-            'name' => $name,
+            'supplier_email' => $email,
+            'supplier_name' => $name,
             'channels' => maybe_serialize($channels),
             'threshold' => $threshold > 0 ? $threshold : null
         );
@@ -216,8 +216,8 @@ class SRWM_Supplier {
         }
         
         $data = array(
-            'email' => $result->email,
-            'name' => $result->name,
+            'email' => $result->supplier_email,
+            'name' => $result->supplier_name,
             'threshold' => $result->threshold,
             'channels' => maybe_unserialize($result->channels) ?: array('email' => true)
         );
@@ -237,7 +237,7 @@ class SRWM_Supplier {
         
         $table = $wpdb->prefix . 'srwm_suppliers';
         
-        $results = $wpdb->get_results(
+        return $wpdb->get_results(
             "SELECT s.*, p.post_title as product_name, wc.stock_quantity as current_stock
              FROM $table s
              JOIN {$wpdb->posts} p ON s.product_id = p.ID
@@ -246,14 +246,6 @@ class SRWM_Supplier {
              ORDER BY p.post_title",
             ARRAY_A
         );
-        
-        // Map the database column names to the expected keys
-        foreach ($results as &$result) {
-            $result['supplier_name'] = $result['name'];
-            $result['supplier_email'] = $result['email'];
-        }
-        
-        return $results;
     }
     
     /**
@@ -382,7 +374,7 @@ class SRWM_Supplier {
         $table = $wpdb->prefix . 'srwm_suppliers';
         
         return $wpdb->get_row($wpdb->prepare(
-            "SELECT * FROM $table WHERE email = %s",
+            "SELECT * FROM $table WHERE supplier_email = %s",
             $email
         ));
     }
@@ -396,7 +388,7 @@ class SRWM_Supplier {
         $table = $wpdb->prefix . 'srwm_suppliers';
         
         return $wpdb->get_results(
-            "SELECT DISTINCT email, name FROM $table ORDER BY name"
+            "SELECT DISTINCT supplier_email, supplier_name FROM $table ORDER BY supplier_name"
         );
     }
 }


### PR DESCRIPTION
 DATABASE COLUMN MISMATCH FIXED

Root Cause Analysis: The error was caused by a mismatch between the actual database table structure and the column names being used in the code. The actual table was created with supplier_name and supplier_email columns, but the code was trying to use name and email.

Actual Database Structure (from main plugin file):

CREATE TABLE wp_srwm_suppliers (
    id bigint(20) NOT NULL AUTO_INCREMENT,
    product_id bigint(20) NOT NULL,
    supplier_name varchar(255) NOT NULL,  -- NOT 'name'
    supplier_email varchar(255) NOT NULL, -- NOT 'email'
    threshold int(11) DEFAULT 5,
    channels longtext,
    auto_generate_po tinyint(1) DEFAULT 0,
    created_at datetime DEFAULT CURRENT_TIMESTAMP, -- NOT 'date_created'
    PRIMARY KEY (id)
)

Fixes Applied:

    Analytics Class (includes/class-srwm-analytics.php):
        Fixed get_supplier_performance() query to use correct column names
        Changed s.name as supplier_name, s.email as supplier_email → s.supplier_name, s.supplier_email
        Changed s.date_created → s.created_at
        Changed GROUP BY s.email → GROUP BY s.supplier_email

    Supplier Class (includes/class-srwm-supplier.php):

        Fixed get_supplier_data() method to use correct column names

        Changed $result->email → $result->supplier_email

        Changed $result->name → $result->supplier_name

        Fixed save_supplier_to_database() method

        Changed 'email' → 'supplier_email'

        Changed 'name' → 'supplier_name'

        Fixed get_supplier_by_email() method

        Changed WHERE email = %s → WHERE supplier_email = %s

        Fixed get_all_suppliers() method

        Changed SELECT DISTINCT email, name → SELECT DISTINCT supplier_email, supplier_name

        Changed ORDER BY name → ORDER BY supplier_name

        Simplified get_products_with_suppliers() method

        Removed unnecessary mapping since database already has correct column names

Result: The database queries should now work correctly with the actual table structure! 🚀

The plugin should now be able to:

    Display supplier performance analytics without errors
    Save and retrieve supplier data correctly
    Show supplier information in the admin dashboard
    Export analytics data properly
