### PR TITLE
Cursor/build wordpress plugin from text file b37d

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -2093,10 +2093,10 @@ class SRWM_Admin {
         }
         
         ?>
-        <div class="wrap srwm-dashboard">
-            <div class="srwm-dashboard-header">
+        <div class="wrap srwm-pro-page">
+            <div class="srwm-pro-header">
                 <h1><?php _e('Stock Thresholds', 'smart-restock-waitlist'); ?></h1>
-                <div class="srwm-dashboard-actions">
+                <div class="srwm-pro-actions">
                     <button class="button button-secondary" onclick="location.href='<?php echo admin_url('admin.php?page=smart-restock-waitlist'); ?>'">
                         <span class="dashicons dashicons-arrow-left-alt"></span>
                         <?php _e('Back to Dashboard', 'smart-restock-waitlist'); ?>


### PR DESCRIPTION
FIXED!

Main Error Fixed:

    Added all missing methods: get_default_email_template(), get_default_whatsapp_template(), get_default_sms_template(), etc.
    Added purchase order methods: get_total_purchase_orders(), get_pending_purchase_orders(), etc.
    Added CSV upload methods: get_csv_upload_links()

Modern Design Applied:

    ✅ One-Click Restock page
    ✅ Multi-Channel Notifications page
    ✅ Email Templates page
    ✅ Purchase Orders page
    ✅ CSV Upload page
    ✅ Stock Thresholds page

All Pro feature pages now have:

    Modern white cards with shadows
    Professional headers and buttons
    Enhanced tables and forms
    Consistent styling throughout

The fatal error is fixed and all Pro pages now have the modern, professional design! 🚀