### PR TITLE
Remove extra closing brace in license manager class

### DIFF
--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -221,7 +221,6 @@ class SRWM_License_Manager {
             error_log('SRWM: Server unreachable: ' . $response->get_error_message());
         }
     }
-    }
     
     /**
      * Check license status


### PR DESCRIPTION
 SYNTAX ERROR FIXED!

The problem was an extra closing brace on line 225. I've removed it and now the file should parse correctly.
🔧 What was wrong:

    }  // This was the correct closing brace for the method
    }  // This was the extra closing brace causing the error

✅ What's fixed:

    }  // Only one closing brace now

The license deactivation should now work properly! Try accessing the plugin again and the syntax error should be gone. You can now test the license deactivation functionality. 🎉