### PR TITLE
Optimize script loading for dashboard and admin pages

### DIFF
--- a/admin/class-srwm-admin-dashboard.php
+++ b/admin/class-srwm-admin-dashboard.php
@@ -24,7 +24,8 @@ class SRWM_Admin_Dashboard {
      * Enqueue dashboard-specific scripts and styles
      */
     public function enqueue_dashboard_scripts($hook) {
-        if (strpos($hook, 'smart-restock-waitlist') === false) {
+        // Only enqueue on the main dashboard page, not on other plugin pages
+        if ($hook !== 'toplevel_page_smart-restock-waitlist') {
             return;
         }
         

--- a/admin/js/dashboard.js
+++ b/admin/js/dashboard.js
@@ -21,6 +21,11 @@
      * Initialize dashboard
      */
     function initDashboard() {
+        // Only initialize if we're on the dashboard page
+        if (!$('.srwm-dashboard').length) {
+            return;
+        }
+        
         initCharts();
         initEventHandlers();
         initRealtimeUpdates();

--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -158,6 +158,11 @@ class SRWM_Admin {
      * Enqueue admin scripts and styles
      */
     public function enqueue_admin_scripts($hook) {
+        // Don't enqueue on license page - it doesn't need these scripts
+        if (strpos($hook, 'smart-restock-waitlist-license') !== false) {
+            return;
+        }
+        
         if (strpos($hook, 'smart-restock-waitlist') === false) {
             return;
         }


### PR DESCRIPTION
LICENSE PAGE "ERROR LOADING DATA" ISSUE FIXED!
🐛 Root Cause Identified:

The "Error loading data" message was appearing on the license page because:

    Dashboard Scripts Loading on License Page: The dashboard JavaScript was being enqueued on ALL plugin pages (including license page)
    AJAX Call on Page Load: The dashboard script automatically calls loadChartData() which makes an AJAX request to srwm_get_dashboard_data
    Missing Dashboard Elements: The license page doesn't have dashboard elements (charts, stats, etc.), so the AJAX call fails
    Error Message Display: When the AJAX fails, it shows "Error loading data" from srwm_dashboard.messages.error

🔧 Fixes Applied:
1. Fixed Dashboard Script Loading ✅

// Before: Loaded on all plugin pages
if (strpos($hook, 'smart-restock-waitlist') === false) {
    return;
}

// After: Only load on main dashboard page
if ($hook !== 'toplevel_page_smart-restock-waitlist') {
    return;
}

2. Fixed Admin Script Loading ✅

// Exclude license page from admin script loading
if (strpos($hook, 'smart-restock-waitlist-license') !== false) {
    return;
}

3. Added JavaScript Safety Check ✅

function initDashboard() {
    // Only initialize if we're on the dashboard page
    if (!$('.srwm-dashboard').length) {
        return;
    }
    
    initCharts();
    initEventHandlers();
    initRealtimeUpdates();
    initTooltips();
}

🎯 What This Fixes:

    ✅ License Page: No more "Error loading data" message
    ✅ Clean Separation: Dashboard scripts only load where needed
    ✅ Better Performance: Reduced unnecessary script loading
    ✅ No Conflicts: License page won't interfere with dashboard functionality

🧪 Test the Fix:

    Go to License page - Should load cleanly without errors
    Check browser console - No JavaScript errors
    Dashboard page - Should still work normally with charts and data
    Other plugin pages - Should work without dashboard script conflicts

📊 Technical Details:

Before Fix:

    Dashboard scripts loaded on: Dashboard, Settings, Analytics, License, Pro Features
    AJAX calls made on every page load
    Error messages displayed when dashboard elements missing

After Fix:

    Dashboard scripts load only on: Dashboard page
    Admin scripts load on: Dashboard, Settings, Analytics, Pro Features (excluding License)
    License page: Clean, no unnecessary scripts or AJAX calls

The license page should now load cleanly without any "Error loading data" messages! The dashboard functionality remains intact on the main dashboard page. 🚀