### PR TITLE
Add debug logging to showAdminMessage and improve notice placement

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -506,11 +506,25 @@
     }
     
     function showAdminMessage(type, message) {
+        console.log('showAdminMessage called:', { type: type, message: message });
+        
         var messageClass = type === 'success' ? 'notice-success' : 'notice-error';
         var $notice = $('<div class="notice ' + messageClass + ' is-dismissible"><p>' + message + '</p></div>');
         
+        console.log('Notice element created:', $notice[0].outerHTML);
+        
         // Insert at the top of the page
-        $('.wrap h1').after($notice);
+        var $target = $('.wrap h1');
+        console.log('Target element found:', $target.length > 0 ? 'yes' : 'no');
+        
+        if ($target.length > 0) {
+            $target.after($notice);
+            console.log('Notice inserted after h1');
+        } else {
+            // Fallback: insert at the beginning of .wrap
+            $('.wrap').prepend($notice);
+            console.log('Notice inserted at beginning of .wrap');
+        }
         
         // Auto-dismiss after 5 seconds
         setTimeout(function() {
@@ -526,6 +540,8 @@
                 $(this).remove();
             });
         });
+        
+        console.log('showAdminMessage completed');
     }
     
     function initTooltips() {


### PR DESCRIPTION
ENHANCED DEBUG LOGGING ADDED!
🔧 What I've Added:

    Function Call Logging: Logs when showAdminMessage is called
    Element Creation Logging: Logs the HTML of the notice element
    Target Element Check: Logs whether the target element (.wrap h1) is found
    Insertion Method Logging: Logs which insertion method is used
    Completion Logging: Logs when the function completes

📋 Testing Instructions:

    Try saving or resetting a threshold again
    Check the browser console for the new debug logs
    Look for these specific logs:

    showAdminMessage called: { type: "success", message: "Threshold saved successfully!" }
    Notice element created: <div class="notice notice-success is-dismissible">...
    Target element found: yes/no
    Notice inserted after h1 / Notice inserted at beginning of .wrap
    showAdminMessage completed

🎯 Expected Results:
If Working Correctly:

    You should see all the debug logs
    The success message should appear on the page
    The message should be green (notice-success)

If Still Not Working:

    We'll see exactly where the issue is:
        Is the function being called?
        Is the element being created?
        Is the target element found?
        Is the insertion working?

🔍 Common Issues This Will Reveal:

    Target Element Missing: If .wrap h1 is not found
    CSS Conflicts: If the element is inserted but not visible
    JavaScript Errors: If the function fails to complete
    Timing Issues: If the function is called but doesn't execute properly

📊 Next Steps:

    Test the functionality with the new debug logging
    Share the console output when you try save/reset
    Let me know if you see the success message on the page
    I'll analyze the logs and provide the final fix

This enhanced debugging will pinpoint exactly where the message display is failing! 🎉