### PR TITLE
Add logging and validation for product threshold saving

### DIFF
--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -1232,8 +1232,15 @@ class SmartRestockWaitlistManager {
         
         // Check if product exists
         $product = wc_get_product($product_id);
+        error_log('SRWM: Product check - product_id: ' . $product_id . ', product exists: ' . ($product ? 'yes' : 'no'));
         if (!$product) {
             wp_die(json_encode(array('success' => false, 'message' => __('Product not found.', 'smart-restock-waitlist'))));
+        }
+        
+        // Check if product is a valid WooCommerce product
+        if (!$product->is_type('simple') && !$product->is_type('variable')) {
+            error_log('SRWM: Product type not supported: ' . $product->get_type());
+            wp_die(json_encode(array('success' => false, 'message' => __('Product type not supported.', 'smart-restock-waitlist'))));
         }
         
         if ($threshold < 0) {
@@ -1241,11 +1248,16 @@ class SmartRestockWaitlistManager {
         }
         
         // Save threshold as product meta
+        error_log('SRWM: About to save threshold - product_id: ' . $product_id . ', threshold: ' . $threshold);
         $result = update_post_meta($product_id, '_srwm_threshold', $threshold);
+        error_log('SRWM: update_post_meta result: ' . ($result !== false ? 'success' : 'failed'));
         
         if ($result !== false) {
             wp_die(json_encode(array('success' => true, 'message' => __('Threshold saved successfully!', 'smart-restock-waitlist'))));
         } else {
+            // Check if the meta already exists
+            $existing_value = get_post_meta($product_id, '_srwm_threshold', true);
+            error_log('SRWM: Existing threshold value: ' . $existing_value);
             wp_die(json_encode(array('success' => false, 'message' => __('Failed to save threshold. Please try again.', 'smart-restock-waitlist'))));
         }
     }


### PR DESCRIPTION
 ENHANCED DEBUG LOGGING ADDED!
🔍 What the Debug Logs Will Show:

    Product Check: Whether the product exists and what type it is
    Save Operation: The exact values being saved
    Update Result: Whether update_post_meta() succeeds or fails
    Existing Value: What the current threshold value is (if any)

📋 Testing Instructions:

    Try saving a threshold again
    Check the WordPress debug log for the new debug entries
    Look for these specific logs:

    SRWM: Product check - product_id: 62, product exists: yes/no
    SRWM: Product type not supported: [product_type] (if applicable)
    SRWM: About to save threshold - product_id: 62, threshold: 5
    SRWM: update_post_meta result: success/failed
    SRWM: Existing threshold value: [value] (if failed)

🎯 Expected Results:
If Working Correctly:

    Product exists: yes
    Product type: simple or variable
    Update result: success
    Success message on frontend

If Still Failing:

    We'll see exactly where the issue is:
        Product doesn't exist
        Product type not supported
        update_post_meta() failing
        Database permission issues

🔍 Common Issues This Will Reveal:

    Product Issues: Product doesn't exist or wrong type
    Database Issues: Permission problems or database errors
    Meta Key Issues: Problems with the meta key _srwm_threshold
    Value Issues: Problems with the threshold value format

📊 Next Steps:

    Test the save functionality with the new debug logging
    Share the debug log entries when you try to save
    I'll analyze the logs and provide the final fix

This enhanced debugging will pinpoint exactly why update_post_meta() is failing! 🎉