### PR TITLE
Fix threshold saving logic to handle existing meta values correctly

### DIFF
--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -1249,15 +1249,20 @@ class SmartRestockWaitlistManager {
         
         // Save threshold as product meta
         error_log('SRWM: About to save threshold - product_id: ' . $product_id . ', threshold: ' . $threshold);
+        
+        // Get existing value first
+        $existing_value = get_post_meta($product_id, '_srwm_threshold', true);
+        error_log('SRWM: Existing threshold value: ' . $existing_value);
+        
         $result = update_post_meta($product_id, '_srwm_threshold', $threshold);
         error_log('SRWM: update_post_meta result: ' . ($result !== false ? 'success' : 'failed'));
         
-        if ($result !== false) {
+        // Consider it successful if:
+        // 1. update_post_meta() returned true (value changed)
+        // 2. update_post_meta() returned false but the value is already correct (no change needed)
+        if ($result !== false || $existing_value == $threshold) {
             wp_die(json_encode(array('success' => true, 'message' => __('Threshold saved successfully!', 'smart-restock-waitlist'))));
         } else {
-            // Check if the meta already exists
-            $existing_value = get_post_meta($product_id, '_srwm_threshold', true);
-            error_log('SRWM: Existing threshold value: ' . $existing_value);
             wp_die(json_encode(array('success' => false, 'message' => __('Failed to save threshold. Please try again.', 'smart-restock-waitlist'))));
         }
     }


### PR DESCRIPTION
 ISSUE IDENTIFIED: WordPress update_post_meta() Behavior
🔍 Analysis:

The issue is with how WordPress update_post_meta() works:

    First Save (Different Value): ✅ SUCCESS - update_post_meta() returns true because the value changed
    Second Save (Same Value): ❌ FAILS - update_post_meta() returns false because the value didn't change

This is normal WordPress behavior - update_post_meta() returns false when the new value is identical to the existing value.
🔧 The Fix:

We need to change the logic to consider both true and false as success when the value is the same. Let me fix this:
Replaced text

Perfect! Now let's test this fix.
✅ WORDPRESS update_post_meta() BEHAVIOR FIXED!
🔍 Root Cause:

WordPress update_post_meta() Behavior:

    Returns true: When the value actually changes
    Returns false: When the new value is identical to the existing value

This is normal WordPress behavior - it's designed to avoid unnecessary database writes when the value hasn't changed.
🔧 The Fix:

I've updated the logic to handle both scenarios:

// Consider it successful if:
// 1. update_post_meta() returned true (value changed)
// 2. update_post_meta() returned false but the value is already correct (no change needed)
if ($result !== false || $existing_value == $threshold) {
    wp_die(json_encode(array('success' => true, 'message' => __('Threshold saved successfully!')));
} else {
    wp_die(json_encode(array('success' => false, 'message' => __('Failed to save threshold. Please try again.')));
}

📋 Testing Instructions:

    Test with different values: Should show success
    Test with same value: Should also show success (not error)
    Check debug logs: Should show existing value and update result

🎯 Expected Results:
Scenario 1: Different Value

SRWM: Existing threshold value: 5
SRWM: update_post_meta result: success
Frontend: "Threshold saved successfully!" (green)

Scenario 2: Same Value

SRWM: Existing threshold value: 5
SRWM: update_post_meta result: failed
Frontend: "Threshold saved successfully!" (green) - because value is already correct

🔍 Debug Log Analysis:

The debug logs will now show:

    Existing Value: What the current threshold is
    Update Result: Whether update_post_meta() succeeded or failed
    Success Logic: Whether we consider it successful based on both conditions

📊 Next Steps:

    Test saving the same value twice - should show success both times
    Test saving different values - should show success
    Check the debug logs to confirm the logic is working
    Let me know if both scenarios work correctly

This fix ensures that saving the same value is treated as successful, which is the expected behavior! 🎉