### PR TITLE
Add global threshold save functionality with AJAX and validation

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -197,6 +197,58 @@
             });
         });
         
+        // Handle global threshold form submission
+        $(document).on('submit', '#srwm-global-threshold-form', function(e) {
+            e.preventDefault();
+            
+            var $form = $(this);
+            var $submitBtn = $form.find('button[type="submit"]');
+            var originalText = $submitBtn.text();
+            var threshold = $form.find('input[name="srwm_global_threshold"]').val();
+            
+            console.log('Global threshold save attempt:', { threshold: threshold, nonce: srwm_admin.nonce });
+            
+            if (!threshold || threshold < 0) {
+                showAdminMessage('error', 'Please enter a valid threshold value.');
+                return;
+            }
+            
+            // Disable submit button and show loading
+            $submitBtn.prop('disabled', true).html('<span class="dashicons dashicons-update"></span> Saving...');
+            
+            var ajaxData = {
+                action: 'srwm_save_global_threshold',
+                nonce: srwm_admin.nonce,
+                global_threshold: threshold
+            };
+            
+            console.log('Global threshold AJAX data:', ajaxData);
+            
+            $.ajax({
+                url: srwm_admin.ajax_url,
+                type: 'POST',
+                dataType: 'json',
+                data: ajaxData,
+                success: function(response) {
+                    console.log('Global threshold response:', response);
+                    console.log('Response success type:', typeof response.success, 'Value:', response.success);
+                    
+                    if (response.success === true || response.success === 'true') {
+                        showAdminMessage('success', response.message || 'Global threshold saved successfully!');
+                    } else {
+                        showAdminMessage('error', response.message || 'Failed to save global threshold.');
+                    }
+                },
+                error: function(xhr, status, error) {
+                    console.log('Global threshold error:', { xhr: xhr, status: status, error: error });
+                    showAdminMessage('error', 'Failed to save global threshold.');
+                },
+                complete: function() {
+                    $submitBtn.prop('disabled', false).html('<span class="dashicons dashicons-saved"></span> ' + originalText);
+                }
+            });
+        });
+        
         // Handle notification settings form submission
         $(document).on('submit', '#srwm-notification-settings-form', function(e) {
             e.preventDefault();

--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -2466,11 +2466,18 @@ class SRWM_Admin {
                     <div class="srwm-global-threshold">
                         <h3><?php _e('Global Default Threshold', 'smart-restock-waitlist'); ?></h3>
                         <p><?php _e('This threshold will be used for all products unless a specific threshold is set.', 'smart-restock-waitlist'); ?></p>
-                        <div class="srwm-form-group">
-                            <label><?php _e('Default Threshold:', 'smart-restock-waitlist'); ?></label>
-                            <input type="number" name="srwm_global_threshold" value="<?php echo esc_attr(get_option('srwm_global_threshold', 5)); ?>" min="0" class="small-text">
-                            <span><?php _e('units', 'smart-restock-waitlist'); ?></span>
-                        </div>
+                        <form id="srwm-global-threshold-form" method="post">
+                            <?php wp_nonce_field('srwm_admin_nonce', 'srwm_admin_nonce'); ?>
+                            <div class="srwm-form-group">
+                                <label><?php _e('Default Threshold:', 'smart-restock-waitlist'); ?></label>
+                                <input type="number" name="srwm_global_threshold" value="<?php echo esc_attr(get_option('srwm_global_threshold', 5)); ?>" min="0" class="small-text">
+                                <span><?php _e('units', 'smart-restock-waitlist'); ?></span>
+                                <button type="submit" class="button button-primary">
+                                    <span class="dashicons dashicons-saved"></span>
+                                    <?php _e('Save Global Threshold', 'smart-restock-waitlist'); ?>
+                                </button>
+                            </div>
+                        </form>
                     </div>
                 </div>
                 

--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -1363,19 +1363,35 @@ class SmartRestockWaitlistManager {
      * AJAX: Save global threshold (Pro)
      */
     public function ajax_save_global_threshold() {
+        error_log('SRWM: Global threshold save handler called');
+        
         check_ajax_referer('srwm_admin_nonce', 'nonce');
         
-        if (!current_user_can('manage_woocommerce') || !$this->license_manager->is_pro_active()) {
-            wp_die(json_encode(array('success' => false, 'message' => __('Insufficient permissions or Pro license required.', 'smart-restock-waitlist'))));
+        if (!current_user_can('manage_woocommerce')) {
+            error_log('SRWM: Global threshold - insufficient permissions');
+            wp_die(json_encode(array('success' => false, 'message' => __('Insufficient permissions.', 'smart-restock-waitlist'))));
+        }
+        
+        if (!$this->license_manager->is_pro_active()) {
+            error_log('SRWM: Global threshold - pro license not active');
+            wp_die(json_encode(array('success' => false, 'message' => __('Pro license required. Please activate your license first.', 'smart-restock-waitlist'))));
+        }
+        
+        if (!isset($_POST['global_threshold'])) {
+            error_log('SRWM: Global threshold - missing data');
+            wp_die(json_encode(array('success' => false, 'message' => __('Global threshold value is required.', 'smart-restock-waitlist'))));
         }
         
         $global_threshold = intval($_POST['global_threshold']);
+        error_log('SRWM: Global threshold value: ' . $global_threshold);
         
         if ($global_threshold < 0) {
+            error_log('SRWM: Global threshold - invalid value');
             wp_die(json_encode(array('success' => false, 'message' => __('Global threshold must be a positive number.', 'smart-restock-waitlist'))));
         }
         
-        update_option('srwm_global_threshold', $global_threshold);
+        $result = update_option('srwm_global_threshold', $global_threshold);
+        error_log('SRWM: Global threshold update_option result: ' . ($result !== false ? 'success' : 'failed'));
         
         wp_die(json_encode(array('success' => true, 'message' => __('Global threshold saved successfully!', 'smart-restock-waitlist'))));
     }


### PR DESCRIPTION
GLOBAL THRESHOLD SAVE FUNCTIONALITY FIXED!
🔧 Fixes Applied:
1. Added Save Button ✅

    Form Wrapper: Wrapped the global threshold input in a proper form
    Save Button: Added a "Save Global Threshold" button with icon
    Nonce Field: Added proper security nonce

2. Added JavaScript Handler ✅

    Form Submission: Handles the form submission via AJAX
    Validation: Validates the threshold value
    Loading State: Shows loading state during save
    Success/Error Messages: Displays appropriate messages

3. Enhanced PHP Handler ✅

    Debug Logging: Added comprehensive debug logging
    Better Error Handling: More specific error messages
    Validation: Proper input validation

🎯 How It Works:
HTML Structure:

<form id="srwm-global-threshold-form" method="post">
    <input type="number" name="srwm_global_threshold" value="5">
    <button type="submit">Save Global Threshold</button>
</form>

JavaScript Handler:

    Prevents Default: Stops form from submitting normally
    AJAX Request: Sends data to srwm_save_global_threshold handler
    Response Handling: Shows success/error messages
    Loading States: Disables button during save

PHP Handler:

    Security Checks: Validates nonce and permissions
    Input Validation: Ensures positive number
    Database Save: Uses update_option() to save
    Response: Returns JSON success/error response

📋 Testing Instructions:

    Go to Stock Thresholds tab
    Change the global threshold value
    Click "Save Global Threshold" button
    Check for success message
    Reload the page - value should persist
    Check browser console for debug logs

🎯 Expected Results:

    ✅ Save Button: Should appear next to the input field
    ✅ Success Message: "Global threshold saved successfully!" (green)
    ✅ Value Persistence: Value should remain after page reload
    ✅ Console Logs: Should show AJAX request and response

🔍 Debug Information:

The debug logs will show:

SRWM: Global threshold save handler called
SRWM: Global threshold value: [value]
SRWM: Global threshold update_option result: success

📊 Next Steps:

    Test the global threshold save functionality
    Confirm the value persists after reload
    Check that individual product thresholds still work
    Let me know if everything works correctly

The global threshold should now save properly and persist across page reloads! 🎉