### PR TITLE
Use site_url() instead of home_url() for consistent URL generation

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -522,7 +522,7 @@
             
             var $btn = $(this);
             var token = $btn.data('token');
-            var link = window.location.origin + '/?srwm_csv_upload=1&token=' + token;
+            var link = srwm_admin.site_url + '/?srwm_csv_upload=1&token=' + token;
             
             // Copy to clipboard
             navigator.clipboard.writeText(link).then(function() {

--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -184,6 +184,7 @@ class SRWM_Admin {
         
         wp_localize_script('srwm-admin', 'srwm_admin', array(
             'ajax_url' => admin_url('admin-ajax.php'),
+            'site_url' => site_url(),
             'nonce' => wp_create_nonce('srwm_admin_nonce'),
             'is_pro' => $this->license_manager->is_pro_active(),
             'messages' => array(

--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -1207,7 +1207,7 @@ class SmartRestockWaitlistManager {
                 $upload_url = add_query_arg(array(
                     'srwm_csv_upload' => '1',
                     'token' => $token
-                ), home_url());
+                ), site_url());
                 
                 wp_die(json_encode(array(
                     'success' => true, 


### PR DESCRIPTION
SV UPLOAD LINK URL FIXED!
🔧 Issues Fixed:
1. Wrong URL Generation ✅

    Problem: home_url() was returning root domain instead of WordPress path
    Fix: Changed to site_url() which includes the WordPress installation path

2. JavaScript Copy Link ✅

    Problem: JavaScript was using wrong URL construction
    Fix: Added site_url to localized script data and used it in JavaScript

🎯 Changes Made:
PHP Fix:

// Before
$upload_url = add_query_arg(array(
    'srwm_csv_upload' => '1',
    'token' => $token
), home_url());

// After  
$upload_url = add_query_arg(array(
    'srwm_csv_upload' => '1',
    'token' => $token
), site_url());

JavaScript Fix:

// Before
var link = window.location.origin + '/?srwm_csv_upload=1&token=' + token;

// After
var link = srwm_admin.site_url + '/?srwm_csv_upload=1&token=' + token;

Localized Script Data:

'site_url' => site_url(),

📋 Expected Results:

Now when you generate a CSV upload link, it should create URLs like:

    Before: http://localhost/?srwm_csv_upload=1&token=...
    After: http://localhost/wordpress/?srwm_csv_upload=1&token=...

🎯 Testing Instructions:

    Go to CSV Upload tab
    Enter a valid email (e.g., supplier@example.com)
    Click "Generate Upload Link"
    Check the generated link - it should now include /wordpress/ in the path
    Test the "Copy Link" button on existing links
    Verify the copied link has the correct path

🔍 What to Check:

    ✅ Generated Link: Should include WordPress path
    ✅ Copy Link Button: Should copy correct URL
    ✅ Link Functionality: Should work when accessed

The CSV upload links should now generate with the correct WordPress installation path! 🚀

Please test the functionality and let me know if the URLs now include the correct path (/wordpress/ in your case).