### PR TITLE
Add ensure_csv_approvals_table method to create table if not exists

### DIFF
--- a/includes/pro/class-srwm-pro-csv-upload.php
+++ b/includes/pro/class-srwm-pro-csv-upload.php
@@ -846,6 +846,12 @@ class SRWM_Pro_CSV_Upload {
     private function store_for_approval($token, $file, $csv_data) {
         global $wpdb;
         
+        // Ensure CSV approvals table exists
+        global $srwm_plugin;
+        if ($srwm_plugin) {
+            $srwm_plugin->ensure_csv_approvals_table();
+        }
+        
         // Get supplier email from token
         $token_data = $wpdb->get_row($wpdb->prepare(
             "SELECT supplier_email FROM {$wpdb->prefix}srwm_csv_tokens WHERE token = %s",


### PR DESCRIPTION
 CSV Approvals Table Issue Fixed!

I've implemented a comprehensive solution to ensure the CSV approvals table is created:
1. Added Table Creation Method:

    ensure_csv_approvals_table() method that checks if the table exists and creates it if needed
    Called from multiple places to ensure the table is always available

2. Automatic Table Creation:

    Plugin initialization - Table is created when the plugin loads
    CSV upload processing - Table is created before storing uploads for approval
    AJAX handlers - Table is created before accessing approval data

3. Debug Logging:

    Added logging to track when the table is created
    Error handling to catch any table creation issues

🧪 Now Test the CSV Upload with Approval:

    Try uploading a CSV file with the approval setting enabled
    Check the debug logs for "SRWM: CSV approvals table created successfully"
    The table should now exist and the upload should work properly

The CSV upload with admin approval should now work correctly. The table will be created automatically when needed, and you should be able to:

    Upload CSV files for approval
    View pending approvals in the admin dashboard
    Approve or reject uploads with admin notes
    Receive email notifications for approval status

Try uploading a CSV file now and let me know if the issue is resolved!