### PR TITLE
Remove debug logging and unnecessary Quick Restock tab styling

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -4999,6 +4999,7 @@ class SRWM_Admin {
                         </div>
                     </div>
                 </div>
+                </div>
                 
                 <!-- Quick Restock Tab -->
                 <div class="srwm-tab-content" id="quick-restock-tab">
@@ -5388,11 +5389,6 @@ class SRWM_Admin {
         /* Ensure tab content is visible */
         #quick-restock-tab {
             min-height: 200px;
-        }
-        
-        #quick-restock-tab.active {
-            display: block !important;
-            visibility: visible !important;
         }
         
         .srwm-suppliers-container {
@@ -6549,15 +6545,6 @@ class SRWM_Admin {
             // Debug: Check if Quick Restock tab content exists
             console.log('Quick Restock tab exists:', $('#quick-restock-tab').length > 0);
             console.log('Quick Restock tab content length:', $('#quick-restock-tab').html().length);
-            console.log('Quick Restock tab HTML:', $('#quick-restock-tab').html().substring(0, 200));
-            
-            // Force show Quick Restock tab for testing
-            setTimeout(function() {
-                console.log('Testing Quick Restock tab visibility...');
-                $('#quick-restock-tab').show().addClass('active');
-                console.log('Quick Restock tab display:', $('#quick-restock-tab').css('display'));
-                console.log('Quick Restock tab visibility:', $('#quick-restock-tab').css('visibility'));
-            }, 1000);
             
             // Search and filter functionality
             $('#supplier-search').on('input', debounce(loadSuppliers, 300));


### PR DESCRIPTION
Root Cause Found and Fixed!
🔍 The Problem:

The CSV Upload tab was missing its closing </div> tag, which was breaking the entire HTML structure. This caused the browser to not properly parse the Quick Restock tab content, making it appear empty.
🔧 The Fix:

    Added Missing Closing Tag - Added the missing </div> for the CSV Upload tab
    Cleaned Up Debugging Code - Removed the forced visibility and excessive debugging
    Simplified CSS - Removed unnecessary !important declarations

📋 Current Structure (Fixed):

<!-- Tab Content Container -->
<div class="srwm-tab-content-container">
    <!-- Suppliers Tab -->
    <div class="srwm-tab-content active" id="suppliers-tab">
        <!-- Suppliers content -->
    </div>
    
    <!-- CSV Upload Tab -->
    <div class="srwm-tab-content" id="csv-upload-tab">
        <!-- CSV Upload content -->
    </div>  <!-- ← This closing tag was missing! -->
    
    <!-- Quick Restock Tab -->
    <div class="srwm-tab-content" id="quick-restock-tab">
        <!-- Quick Restock content -->
    </div>
</div>

🎯 What You Should See Now:

When you click on the "Quick Restock" tab, you should see:

    ✅ Header Section - "Quick Restock Operations" with "Generate Quick Restock Link" button
    ✅ Info Cards - Two cards explaining the functionality
    ✅ Quick Restock Links Table - Shows all generated links
    ✅ Configuration Section - Information about the feature
