### PR TITLE
Improve CSV upload links loading and error handling in admin interface

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -6988,14 +6988,15 @@ class SRWM_Admin {
                     // Load content based on tab
                     if (tabId === 'quick-restock') {
                         loadQuickRestockProducts();
+                    } else if (tabId === 'csv-upload') {
+                        loadUploadLinks();
                     }
                 });
             
             // Load suppliers on page load
             loadSuppliers();
             
-            // Load upload links on page load
-            loadUploadLinks();
+
             
             // Load quick restock links on page load
             loadQuickRestockLinks();
@@ -7003,6 +7004,11 @@ class SRWM_Admin {
             // Load products if Quick Restock tab is active
             if ($('#quick-restock-tab').hasClass('active')) {
                 loadQuickRestockProducts();
+            }
+            
+            // Load upload links if CSV Upload tab is active
+            if ($('#csv-upload-tab').hasClass('active')) {
+                loadUploadLinks();
             }
             
             // Debug: Check if Quick Restock tab content exists
@@ -7448,6 +7454,8 @@ class SRWM_Admin {
                 const searchTerm = $('#upload-links-search').val();
                 const statusFilter = $('#upload-links-status-filter').val();
                 
+                console.log('Loading upload links with params:', { page, searchTerm, statusFilter });
+                
                 $.ajax({
                     url: ajaxurl,
                     type: 'POST',
@@ -7460,6 +7468,7 @@ class SRWM_Admin {
                         status: statusFilter
                     },
                     success: function(response) {
+                        console.log('Upload links AJAX response:', response);
                         if (response.success) {
                             const data = response.data;
                             displayUploadLinks(data.links, data.pagination);
@@ -7467,7 +7476,8 @@ class SRWM_Admin {
                             $('#upload-links-tbody').html('<tr><td colspan="6" class="srwm-error">Error loading upload links: ' + response.data + '</td></tr>');
                         }
                     },
-                    error: function() {
+                    error: function(xhr, status, error) {
+                        console.error('Upload links AJAX error:', { xhr, status, error });
                         $('#upload-links-tbody').html('<tr><td colspan="6" class="srwm-error">Error loading upload links. Please try again.</td></tr>');
                     }
                 });

--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -2567,6 +2567,10 @@ class SmartRestockWaitlistManager {
         
         $total_count = $wpdb->get_var($count_query);
         
+        if ($total_count === null) {
+            wp_send_json_error(__('Failed to get total count.', 'smart-restock-waitlist'));
+        }
+        
         // Calculate offset
         $offset = ($page - 1) * $per_page;
         
@@ -2584,6 +2588,10 @@ class SmartRestockWaitlistManager {
         $query_params[] = $offset;
         
         $links = $wpdb->get_results($wpdb->prepare($query, $query_params));
+        
+        if ($links === null) {
+            wp_send_json_error(__('Failed to retrieve upload links.', 'smart-restock-waitlist'));
+        }
         
         // Add upload count for each link
         foreach ($links as $link) {


### PR DESCRIPTION
 CSV Upload Links Loading Issue Fixed!
🔧 Root Cause:

The loadUploadLinks() function was being called immediately when the page loaded, but the CSV Upload tab wasn't active yet, causing the AJAX request to fail or not display properly.
🛠️ Solution Applied:

    Removed Premature Loading - Removed the function call from page load
    Added Tab-Specific Loading - Upload links now load only when the CSV Upload tab is clicked
    Enhanced Error Handling - Added better error checking in the backend function
    Added Debugging - Console logs to help troubleshoot any remaining issues

🎯 How It Works Now:

    Page Load - Only loads suppliers and quick restock links
    Tab Click - When you click the "CSV Upload" tab, it loads the upload links
    Smart Loading - Links are loaded with proper pagination and filtering
    Error Handling - Better error messages if something goes wrong

📋 What You Should See:

    CSV Upload Tab - Click it and upload links should load immediately
    10 Links Per Page - With pagination controls at the bottom
    Search & Filters - Work properly with the pagination system
    Console Logs - Debug information to help troubleshoot

Try clicking on the "CSV Upload" tab now - the upload links should load properly! 🚀