### PR TITLE
Refactor pagination to support multiple tabs with dynamic loading

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -7152,12 +7152,20 @@ class SRWM_Admin {
                 clearProductSelection();
             });
             
-            // Pagination event delegation for upload links
+            // Pagination event delegation for upload links and quick restock
             $(document).on('click', '.srwm-pagination-btn, .srwm-page-number', function() {
                 const page = $(this).data('page');
                 if (page) {
                     console.log('Pagination clicked, loading page:', page);
-                    loadUploadLinks(page);
+                    
+                    // Determine which pagination was clicked based on the active tab
+                    const activeTab = $('.srwm-tab-button.active').attr('data-tab');
+                    
+                    if (activeTab === 'quick-restock') {
+                        loadQuickRestockProducts(page);
+                    } else if (activeTab === 'csv-upload') {
+                        loadUploadLinks(page);
+                    }
                 }
             });
             
@@ -8178,7 +8186,7 @@ class SRWM_Admin {
                 });
                 
                 // Add pagination controls
-                if (pagination && pagination.total_pages > 1) {
+                if (pagination && pagination.total_count > 0) {
                     html += generatePaginationControls(pagination);
                 }
                 
@@ -8191,7 +8199,7 @@ class SRWM_Admin {
                 
                 // Previous button
                 if (pagination.has_prev) {
-                    html += `<button class="srwm-pagination-btn" onclick="loadQuickRestockProducts(${pagination.current_page - 1})">
+                    html += `<button class="srwm-pagination-btn" data-page="${pagination.current_page - 1}">
                                 <i class="fas fa-chevron-left"></i> Previous
                             </button>`;
                 }
@@ -8203,7 +8211,7 @@ class SRWM_Admin {
                         html += `<span class="srwm-page-number active">${i}</span>`;
                     } else if (i === 1 || i === pagination.total_pages || 
                               (i >= pagination.current_page - 2 && i <= pagination.current_page + 2)) {
-                        html += `<button class="srwm-page-number" onclick="loadQuickRestockProducts(${i})">${i}</button>`;
+                        html += `<button class="srwm-page-number" data-page="${i}">${i}</button>`;
                     } else if (i === pagination.current_page - 3 || i === pagination.current_page + 3) {
                         html += '<span class="srwm-page-ellipsis">...</span>';
                     }
@@ -8212,7 +8220,7 @@ class SRWM_Admin {
                 
                 // Next button
                 if (pagination.has_next) {
-                    html += `<button class="srwm-pagination-btn" onclick="loadQuickRestockProducts(${pagination.current_page + 1})">
+                    html += `<button class="srwm-pagination-btn" data-page="${pagination.current_page + 1}">
                                 Next <i class="fas fa-chevron-right"></i>
                             </button>`;
                 }


### PR DESCRIPTION
Quick Restock Pagination Fixed!
🔧 Issues Identified & Fixed:

    Same Problem as CSV Upload - Quick Restock pagination was using onclick attributes with functions not globally accessible
    Conditional Display - Pagination was only showing when total_pages > 1, but should show when total_count > 0
    Event Delegation - Needed to handle both CSV Upload and Quick Restock pagination in one event handler

🛠️ Solutions Applied:

    Replaced Inline onclick with Event Delegation:
        Changed from onclick="loadQuickRestockProducts(page)" to data-page="page"
        Updated event delegation to handle both pagination types

    Smart Event Routing:
        Added logic to determine which tab is active
        Routes pagination clicks to the correct function based on active tab
        Uses $('.srwm-tab-button.active').attr('data-tab') to identify context

    Improved Conditions:
        Changed from total_pages > 1 to total_count > 0
        Now shows pagination even with 1 page if there are products

    Unified Styling:
        Both pagination systems now use the same CSS classes
        Consistent visual appearance and behavior

🎯 What's Fixed:

    Quick Restock Pagination - Now properly clickable and functional
    Page Navigation - Previous/Next buttons work correctly
    Page Numbers - Individual page number buttons work
    Visual Feedback - Same hover effects and active state styling as CSV Upload
    Event Handling - Proper event delegation for dynamic content
    Context Awareness - Automatically detects which tab is active

📋 How It Works Now:

    Click Previous/Next - Loads the previous or next page of products
    Click Page Numbers - Jumps directly to that page of products
    Visual Feedback - Current page is highlighted, hover effects on buttons
    Page Info - Shows "Showing X to Y of Z products"
    Smart Routing - Automatically knows whether to load products or upload links

🔄 Event Flow:

    User clicks pagination button → Event delegation catches it
    Check active tab → Determines if it's Quick Restock or CSV Upload
    Route to correct function → loadQuickRestockProducts(page) or loadUploadLinks(page)
    Load new data → AJAX request for the specific page
    Update display → Show new products/links with updated pagination

Try clicking the pagination buttons in the Quick Restock tab now - they should work exactly like the CSV Upload tab! 🚀