### PR TITLE
Fix conditional statement in admin template for pro license check

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -821,7 +821,7 @@ class SRWM_Admin {
                     <?php endif; ?>
                 </div>
                 </div>
-                <?php elseif (!$this->license_manager->is_pro_active()): ?>
+                <?php if (!$this->license_manager->is_pro_active()): ?>
                 <div class="srwm-pro-card">
                     <div class="srwm-pro-card-header">
                         <h2><?php _e('Supplier Management', 'smart-restock-waitlist'); ?></h2>


### PR DESCRIPTION
SYNTAX ERROR FIXED!

The issue was:

    Line 824 had <?php elseif (!$this->license_manager->is_pro_active()): ?>
    But there was no corresponding opening <?php if statement before it

The fix:

    Changed <?php elseif to <?php if to make it a separate conditional block
    Now it properly shows the supplier management preview for free users

The plugin should now work without syntax errors! 🚀

The structure is now:

<?php if ($this->license_manager->is_pro_active() && !empty($supplier_products)): ?>
    // Show supplier products table for Pro users
<?php endif; ?>

<?php if (!$this->license_manager->is_pro_active()): ?>
    // Show upgrade prompt for free users
<?php endif; ?>

This maintains the same functionality while fixing the syntax error.