### PR TITLE
Remove unnecessary conditional check for waitlist products display

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -722,7 +722,6 @@ class SRWM_Admin {
                         </div>
                     </div>
                     
-                    <?php if (!empty($waitlist_products)): ?>
                     <div class="srwm-table-container">
                         <table class="srwm-modern-table srwm-interactive-table" id="srwm-waitlist-table">
                             <thead>


### PR DESCRIPTION
SYNTAX ERROR FIXED!
🔧 What I Fixed:

    Removed Duplicate If Statement: Removed the nested <?php if (!empty($waitlist_products)): ?> that was causing the syntax error
    Corrected PHP Structure: Now the structure is:
        Outer if statement (line 693)
        Real data table (if products exist)
        else clause (line 784)
        Demo data table (if no products)
        endif (line 901)

🎯 The Plugin Should Now Work:

    No More Syntax Error: The PHP parse error should be resolved
    Interactive Features Visible: Search box, filter dropdown, and demo table should be visible
    All Functionality Preserved: Existing features remain intact

Try refreshing the dashboard page now! The syntax error should be gone and you should see the interactive table features. 🎉