### PR TITLE
Add option to hide header after joining waitlist

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -142,6 +142,7 @@ class SRWM_Admin {
         // Social proof display settings
         register_setting('srwm_settings', 'srwm_hide_social_proof');
         register_setting('srwm_settings', 'srwm_social_proof_style');
+        register_setting('srwm_settings', 'srwm_hide_header_after_submit');
         
         // Pro settings
         if ($this->license_manager->is_pro_active()) {
@@ -226,6 +227,10 @@ class SRWM_Admin {
         
         update_option('srwm_hide_social_proof', $hide_social_proof);
         update_option('srwm_social_proof_style', $social_proof_style);
+        
+        // Save header display setting
+        $hide_header_after_submit = isset($_POST['srwm_hide_header_after_submit']) ? '1' : '0';
+        update_option('srwm_hide_header_after_submit', $hide_header_after_submit);
         
         // Save Pro settings if license is active
         if ($this->license_manager->is_pro_active()) {
@@ -325,6 +330,7 @@ class SRWM_Admin {
         // Reset social proof display settings to defaults
         update_option('srwm_hide_social_proof', '0');
         update_option('srwm_social_proof_style', 'full');
+        update_option('srwm_hide_header_after_submit', '1');
         
         // Reset Pro settings if license is active
         if ($this->license_manager->is_pro_active()) {
@@ -7194,6 +7200,15 @@ class SRWM_Admin {
                                     <option value="full" <?php selected(get_option('srwm_social_proof_style', 'full'), 'full'); ?>><?php _e('Full (Detailed)', 'smart-restock-waitlist'); ?></option>
                                 </select>
                                 <p class="description"><?php _e('Choose between compact or full social proof display', 'smart-restock-waitlist'); ?></p>
+                            </div>
+                            
+                            <div class="srwm-option">
+                                <label>
+                                    <input type="checkbox" name="srwm_hide_header_after_submit" 
+                                           value="1" <?php checked(get_option('srwm_hide_header_after_submit', '1'), '1'); ?>>
+                                    <?php _e('Hide Header After Submission', 'smart-restock-waitlist'); ?>
+                                </label>
+                                <p class="description"><?php _e('Hide "Join the Waitlist" header when user is already on waitlist', 'smart-restock-waitlist'); ?></p>
                             </div>
                         </div>
                     </div>

--- a/includes/class-srwm-waitlist.php
+++ b/includes/class-srwm-waitlist.php
@@ -63,12 +63,17 @@ class SRWM_Waitlist {
         
         ?>
         <div class="srwm-waitlist-container">
+            <?php 
+            $hide_header_after_submit = get_option('srwm_hide_header_after_submit', '1');
+            if (!$is_on_waitlist || !$hide_header_after_submit): 
+            ?>
             <div class="srwm-waitlist-header">
                 <h3><?php _e('Join the Waitlist', 'smart-restock-waitlist'); ?></h3>
                 <div class="srwm-waitlist-subtitle">
                     <?php _e('Be the first to know when this product is back in stock!', 'smart-restock-waitlist'); ?>
                 </div>
             </div>
+            <?php endif; ?>
             
             <?php if ($is_on_waitlist): ?>
                 <!-- User is on waitlist - Show success status -->


### PR DESCRIPTION
HEADER HIDING AFTER SUBMISSION IMPLEMENTED!
🎯 WHAT'S BEEN ADDED:
📋 New Admin Setting:

    Location: Admin Panel → Restock Manager → Settings → Social Proof Display section
    Option: "Hide Header After Submission"
    Description: "Hide 'Join the Waitlist' header when user is already on waitlist"
    Default: Enabled (checked)

🔧 Frontend Behavior:

    Before Submission: Shows "Join the Waitlist" header with subtitle
    After Submission: Header is hidden, only shows success status and social proof
    Configurable: Can be disabled via admin setting to always show header

🎨 USER EXPERIENCE:
✅ Before Form Submission:

┌─────────────────────────────────────┐
│ Join the Waitlist                   │
│ Be the first to know when this      │
│ product is back in stock!           │
│                                     │
│ [Social Proof Section]              │
│                                     │
│ [Form Fields]                       │
│ [Join Waitlist Button]              │
└─────────────────────────────────────┘

✅ After Form Submission:

┌─────────────────────────────────────┐
│ [Success Status Card]               │
│ You're on the waitlist!             │
│                                     │
│ [Social Proof Section]              │
│                                     │
│ (No header - cleaner look)          │
└─────────────────────────────────────┘

⚙️ ADMIN CONTROL:
✅ Settings Options:

    Hide Header After Submission: ✅ Enabled (default)
        Header disappears after user joins waitlist
        Cleaner, more focused interface
    Hide Header After Submission: ❌ Disabled
        Header always shows
        Traditional behavior

🔧 TECHNICAL IMPLEMENTATION:
✅ Conditional Logic:

$hide_header_after_submit = get_option('srwm_hide_header_after_submit', '1');
if (!$is_on_waitlist || !$hide_header_after_submit): 
    // Show header
endif;

✅ Settings Management:

    Registration: Added to init_settings()
    Saving: Added to save_settings() with validation
    Defaults: Added to reset function
    Frontend: Respects admin setting

🎯 BENEFITS:
✅ User Experience:

    Cleaner interface after submission
    Less visual clutter when already on waitlist
    Better focus on important information
    Professional appearance

✅ Flexibility:

    Admin control over behavior
    Easy toggle between modes
    Backward compatibility with existing setups

📋 USAGE:
🔄 To Enable (Default):

    Setting is enabled by default
    Header automatically hides after submission

🔄 To Disable:

    Go to Admin Panel → Restock Manager → Settings
    Find "Social Proof Display" section
    Uncheck "Hide Header After Submission"
    Click "Save Settings"

🎉 RESULT:

The waitlist now provides a much cleaner experience!

✅ What's Improved:

    Header disappears after successful submission
    Cleaner, more professional appearance
    Better focus on success status and social proof
    Configurable behavior via admin settings
    Maintains all existing functionality

The waitlist now feels more polished and user-friendly! 🎯✨