### PR TITLE
Remove extra closing brace in admin class

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -220,7 +220,6 @@ class SRWM_Admin {
             register_setting('srwm_notifications', 'srwm_sms_template');
         }
     }
-    }
     
 
     


### PR DESCRIPTION
 SYNTAX ERROR FIXED!

The issue was:

    An extra closing brace } on line 220 after the init_settings() method
    This caused PHP to think the class was ending prematurely
    When it encountered the next private function reset_email_templates() method, it expected the end of file

The fix:

    Removed the extra closing brace
    Now the class structure is properly balanced

The plugin should now work without any syntax errors! 🎉