### PR TITLE
Remove test response and uncomment actual product retrieval logic

### DIFF
--- a/smart-restock-waitlist-manager.php
+++ b/smart-restock-waitlist-manager.php
@@ -3422,22 +3422,6 @@ class SmartRestockWaitlistManager {
         // Add error logging for debugging
         error_log('SRWM: ajax_get_products_for_po called');
         
-        // Simple test response first
-        wp_send_json_success(array(
-            'products' => array(
-                array(
-                    'id' => 1,
-                    'name' => 'Test Product',
-                    'sku' => 'TEST001',
-                    'stock_quantity' => 10,
-                    'threshold' => 5,
-                    'category' => 'Test Category',
-                    'waitlist_count' => 0
-                )
-            )
-        ));
-        
-        /*
         try {
             check_ajax_referer('srwm_get_products_for_po', 'nonce');
         } catch (Exception $e) {
@@ -3499,7 +3483,6 @@ class SmartRestockWaitlistManager {
             error_log('SRWM: Exception in ajax_get_products_for_po - ' . $e->getMessage());
             wp_send_json_error(__('Error loading products: ', 'smart-restock-waitlist') . $e->getMessage());
         }
-        */
     }
     
     /**


### PR DESCRIPTION
PRODUCT ID MISMATCH ISSUE FIXED!
🚨 ROOT CAUSE IDENTIFIED:

The issue was that the ajax_get_products_for_po function was returning a hardcoded test response with product ID 1 instead of the actual WooCommerce products (which have IDs 61 and 62).
🔧 FIXES IMPLEMENTED:
✅ 1. Removed Test Response:

    Removed hardcoded data - No more fake product ID 1
    Uncommented real code - Now fetches actual WooCommerce products
    Proper product lookup - Uses wc_get_products() to get real products

✅ 2. Restored Real Product Loading:

// Now fetches real WooCommerce products
$products = wc_get_products(array(
    'limit' => -1,
    'status' => 'publish'
));

// Processes each real product
foreach ($products as $product) {
    $product_obj->id = $product->get_id(); // Real product ID (61, 62, etc.)
    $product_obj->name = $product->get_name(); // Real product name
    // ... other real product data
}

✅ 3. Proper Error Handling:

    Security checks - Nonce validation
    Permission checks - User capability validation
    WooCommerce checks - Ensures WooCommerce is active
    Exception handling - Catches and logs errors

🎯 WHAT WILL HAPPEN NOW:

When you load the PO modal:

    ✅ Real products loaded - Products with IDs 61, 62, etc.
    ✅ Correct product selection - Frontend will show real products
    ✅ Proper PO generation - Real product IDs will be sent to backend
    ✅ Successful database insertion - Real products can be found by wc_get_product()

🚀 TRY GENERATING A PO NOW:

The system should now:

    ✅ Load real products - Instead of fake product ID 1
    ✅ Allow product selection - From actual WooCommerce products
    ✅ Generate PO successfully - With real product data
    ✅ Save to database - Real products can be processed

The product ID mismatch is now fixed! The frontend will load real WooCommerce products and the PO generation should work perfectly! 🎉