### PR TITLE
Move email templates submenu to be available for all users

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -98,6 +98,16 @@ class SRWM_Admin {
             );
         }
         
+        // Email Templates - available for all users (free and pro)
+        add_submenu_page(
+            'smart-restock-waitlist',
+            __('Email Templates', 'smart-restock-waitlist'),
+            __('Email Templates', 'smart-restock-waitlist'),
+            'manage_woocommerce',
+            'smart-restock-waitlist-templates',
+            array($this, 'render_templates_page')
+        );
+        
         // Pro features menu items - always check current license status
         if ($this->license_manager->is_pro_active()) {
             add_submenu_page(
@@ -107,15 +117,6 @@ class SRWM_Admin {
                 'manage_woocommerce',
                 'smart-restock-waitlist-notifications',
                 array($this, 'render_notifications_page')
-            );
-            
-            add_submenu_page(
-                'smart-restock-waitlist',
-                __('Email Templates', 'smart-restock-waitlist'),
-                __('Email Templates', 'smart-restock-waitlist'),
-                'manage_woocommerce',
-                'smart-restock-waitlist-templates',
-                array($this, 'render_templates_page')
             );
             
             add_submenu_page(


### PR DESCRIPTION
Perfect! I can see that the Email Templates page is already properly structured for free users. The function:

    ✅ No pro-only restrictions at the function level - The function itself doesn't check for pro license
    ✅ Free templates are available - "Waitlist Registration Email" and "Restock Notification Email" are available for all users
    ✅ Pro templates are conditionally shown - Only the "Supplier Notification Email" is wrapped in <?php if ($this->license_manager->is_pro_active()): ?>
    ✅ Template management tools are available - The reset and cleanup tools are available for all users

The fix I made should resolve the issue. The Email Templates tab is now visible for free users, and they can access:

    Waitlist Registration Email (free)
    Restock Notification Email (free)
    Template Management Tools (free)
    Supplier Notification Email (pro only - conditionally shown)

Let me test this by checking if there are any other references to the email templates tab that might need updating:
Grepped codebase for "smart-restock-waitlist-templates"

Great! The references look correct. Now let me also check if there are any CSS classes or styling that might need to be updated for the free version:
Grepped codebase for "srwm-pro-page"

I can see that the Email Templates page uses the srwm-pro-page class. This is fine since it's just a CSS class name and doesn't affect functionality. The styling will work correctly for both free and pro users.

Let me also check if there are any other references to the email templates in the settings that might need updating:
Grepped codebase for "srwm_templates"

Perfect! The settings are properly registered and the form uses the correct settings group.
Summary

I've successfully fixed the Email Templates tab visibility issue for the free version. Here's what I did:
✅ Problem Identified

The Email Templates tab was inside the pro features block (if ($this->license_manager->is_pro_active())), making it only visible to pro users.
✅ Solution Implemented

    Moved Email Templates tab outside the pro block - Now it's available for all users (free and pro)
    Maintained proper structure - The tab is positioned between Settings and the pro features
    Preserved conditional pro content - Only the "Supplier Notification Email" template is conditionally shown for pro users

✅ What Free Users Can Now Access

    Waitlist Registration Email template
    Restock Notification Email template
    Template Management Tools (reset to defaults, force cleanup)
    Save functionality for all templates

✅ What Pro Users Get Additionally

    Supplier Notification Email template (conditionally shown)
