### PR TITLE
Add restock email template and change PO email template method visibi…

### DIFF
--- a/includes/class-srwm-admin.php
+++ b/includes/class-srwm-admin.php
@@ -6579,6 +6579,36 @@ This email was sent to you because you joined the waitlist for {product_name}.
 If you no longer wish to receive these emails, please contact us.';
     }
     
+    /**
+     * Get default restock email template
+     */
+    public function get_default_restock_email_template() {
+        $site_name = get_bloginfo('name');
+        $site_url = get_bloginfo('url');
+        $admin_email = get_option('admin_email');
+        
+        return 'Hi {customer_name},
+
+Great news! {product_name} is back in stock and ready for purchase.
+
+You can purchase it here: {product_url}
+
+Current stock level: {stock_quantity} units available.
+
+Due to high demand, we recommend purchasing soon to secure your item. Stock levels may be limited.
+
+If you have any questions, please contact our customer support team at ' . $admin_email . '.
+
+Thank you for your patience and loyalty!
+
+Best regards,
+' . $site_name . '
+' . $site_url . '
+
+This email was sent to you because you joined the waitlist for {product_name}.
+If you no longer wish to receive these emails, please contact us.';
+    }
+    
     
     
     /**
@@ -6701,7 +6731,7 @@ If you no longer wish to receive these emails, please contact us.';
     /**
      * Get default purchase order email template
      */
-    private function get_default_po_email_template() {
+    public function get_default_po_email_template() {
         return "Hi {supplier_name},\n\n" .
                "Please find attached Purchase Order #{po_number} for the following items:\n\n" .
                "Product: {product_name}\n" .


### PR DESCRIPTION
Problem Fixed Successfully!
Issue Identified:

The Email Templates tab was causing a fatal error because the get_default_restock_email_template() method was missing, and the get_default_po_email_template() method was private but being called from a public context.
Solutions Implemented:

    ✅ Added Missing Method: Created the get_default_restock_email_template() method with a professional plain text template that includes:
        Customer greeting
        Product restock notification
        Purchase link
        Stock quantity information
        Contact information
        Professional closing

    ✅ Fixed Method Visibility: Changed get_default_po_email_template() from private to public so it can be called from the email templates page.

    ✅ Confirmed Email Templates Tab Accessibility: The Email Templates tab is properly positioned outside the pro features block, making it available for all users (free and pro).

What Free Users Can Now Access:

    ✅ Waitlist Registration Email template
    ✅ Restock Notification Email template
    ✅ Template Management Tools (reset to defaults, force cleanup)
    ✅ Save functionality for all templates
    ✅ Professional default templates that work correctly

What Pro Users Get Additionally:

    ✅ Supplier Notification Email template (conditionally shown)

Template Features:

    ✅ Plain text format (as requested)
    ✅ Professional tone
    ✅ Proper placeholders for dynamic content
    ✅ Contact information included
    ✅ Responsive design in the admin interface

The Email Templates tab should now be fully functional for free users without any fatal errors. You can access it from the admin menu under "Restock Manager" → "Email Templates".