### PR TITLE
Add debug output and logging for pro restock request handler

### DIFF
--- a/includes/pro/class-srwm-pro-restock.php
+++ b/includes/pro/class-srwm-pro-restock.php
@@ -29,10 +29,15 @@ class SRWM_Pro_Restock {
      * Handle restock request from supplier link
      */
     public function handle_restock_request() {
+        error_log('SRWM_PRO: Pro restock handler running for token: ' . (isset($_GET['srwm_restock']) ? $_GET['srwm_restock'] : 'NONE'));
         if (!isset($_GET['srwm_restock']) || !isset($_GET['product_id'])) {
             return;
         }
-        error_log('SRWM_PRO: Pro restock handler running for token: ' . $_GET['srwm_restock']);
+        // DEBUG: Force output to confirm handler is running
+        if (isset($_GET['srwm_restock'])) {
+            echo '<h1>SRWM_PRO: Pro restock handler reached for token: ' . esc_html($_GET['srwm_restock']) . '</h1>';
+            exit;
+        }
         
         $token = sanitize_text_field($_GET['srwm_restock']);
         $product_id = intval($_GET['product_id']);


### PR DESCRIPTION
Debug logging and a forced output have been committed to the Pro restock handler.
Now, when you visit a quick restock link, you should see a clear message (SRWM_PRO: Pro restock handler reached for token: ...) and the request will stop there.

What to do next:

    Visit your quick restock link in the browser.
    You should see the debug message.
    If you do, the handler is running and we can proceed to restore the real form logic.
    If you do NOT see the message, let me know and we will trace further.
