### PR TITLE
Remove debug output from restock handler method

### DIFF
--- a/includes/pro/class-srwm-pro-restock.php
+++ b/includes/pro/class-srwm-pro-restock.php
@@ -33,19 +33,11 @@ class SRWM_Pro_Restock {
         if (!isset($_GET['srwm_restock']) || !isset($_GET['product_id'])) {
             return;
         }
-        // DEBUG: Force output to confirm handler is running
-        if (isset($_GET['srwm_restock'])) {
-            echo '<h1>SRWM_PRO: Pro restock handler reached for token: ' . esc_html($_GET['srwm_restock']) . '</h1>';
-            exit;
-        }
-        
         $token = sanitize_text_field($_GET['srwm_restock']);
         $product_id = intval($_GET['product_id']);
-        
         if (!$this->validate_restock_token($token, $product_id)) {
             wp_die(__('Invalid or expired restock link.', 'smart-restock-waitlist'));
         }
-        
         // Handle the restock form submission
         if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['srwm_restock_submit'])) {
             $this->process_restock_request($product_id, $token);


### PR DESCRIPTION
Let’s Commit the Fix:

I will:

    Remove the debug echo and exit from handle_restock_request.
    Restore the original logic so the form is displayed.

Let’s do it!

✅ The debug output and exit have been removed from the Pro handler.
The original logic is restored:

    If the token is valid, the restock form will be displayed.
    If the form is submitted, the stock will be updated.

What to do next:

    Visit your quick restock link in the browser.
    You should now see the actual restock form (not a blank page).

Let me know if you see the form, or if you encounter any errors or issues!