### PR TITLE
Debug restock handler: Add logging and temporarily disable token vali…

### DIFF
--- a/includes/pro/class-srwm-pro-restock.php
+++ b/includes/pro/class-srwm-pro-restock.php
@@ -29,21 +29,19 @@ class SRWM_Pro_Restock {
      * Handle restock request from supplier link
      */
     public function handle_restock_request() {
+        echo '<!-- SRWM_PRO: handler entry -->'; @flush();
         error_log('SRWM_PRO: Pro restock handler running for token: ' . (isset($_GET['srwm_restock']) ? $_GET['srwm_restock'] : 'NONE'));
         if (!isset($_GET['srwm_restock']) || !isset($_GET['product_id'])) {
             return;
         }
         $token = sanitize_text_field($_GET['srwm_restock']);
         $product_id = intval($_GET['product_id']);
-        if (!$this->validate_restock_token($token, $product_id)) {
-            wp_die(__('Invalid or expired restock link.', 'smart-restock-waitlist'));
-        }
-        // Handle the restock form submission
-        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['srwm_restock_submit'])) {
-            $this->process_restock_request($product_id, $token);
-        } else {
-            $this->display_restock_form($product_id, $token);
-        }
+        // TEMP: Comment out token validation for debugging
+        // if (!$this->validate_restock_token($token, $product_id)) {
+        //     wp_die(__('Invalid or expired restock link.', 'smart-restock-waitlist'));
+        // }
+        // Always show the form for debugging
+        $this->display_restock_form($product_id, $token);
     }
     
     /**
@@ -67,6 +65,7 @@ class SRWM_Pro_Restock {
      * Display restock form for supplier
      */
     private function display_restock_form($product_id, $token) {
+        echo '<!-- SRWM_PRO: display_restock_form entry -->'; @flush();
         $product = wc_get_product($product_id);
         
         if (!$product) {


### PR DESCRIPTION
Debug echos have been committed:

    At the very top of handle_restock_request.
    At the very top of display_restock_form.
    Token validation is temporarily bypassed so the form should always attempt to display.

What to do next:

    Visit your quick restock link in the browser.
    View the page source (Ctrl+U or right-click → View Source).
    Look for:
        <!-- SRWM_PRO: handler entry -->
        <!-- SRWM_PRO: display_restock_form entry -->

Let me know:

    Do you see these comments in the source?
    Is there still a blank page, or do you see any error or partial output?
