### PR TITLE
Debug restock form display with diagnostic output and early exit

### DIFF
--- a/includes/pro/class-srwm-pro-restock.php
+++ b/includes/pro/class-srwm-pro-restock.php
@@ -65,7 +65,7 @@ class SRWM_Pro_Restock {
      * Display restock form for supplier
      */
     private function display_restock_form($product_id, $token) {
-        echo '<!-- SRWM_PRO: display_restock_form entry -->'; @flush();
+        echo '<h1>SRWM_PRO: display_restock_form reached</h1>'; exit;
         $product = wc_get_product($product_id);
         
         if (!$product) {


### PR DESCRIPTION
✅ Committed:
A simple debug output (<h1>SRWM_PRO: display_restock_form reached</h1>) and exit; are now at the very top of display_restock_form.

What to do next:

    Visit your quick restock link in the browser.
    You should see a white page with the message:
    SRWM_PRO: display_restock_form reached

Let me know if you see this message or if you still see a blank page or any error.
This will confirm if the function is being called at all.